### PR TITLE
support bitwidth >= 8, and bitpack run with less than 8 values

### DIFF
--- a/parquet/__init__.py
+++ b/parquet/__init__.py
@@ -277,7 +277,6 @@ def read_data_page(fo, schema_helper, page_header, column_metadata,
                                            bit_width)
 
         logger.debug("  Definition levels: %s", len(definition_levels))
-        #             ",".join([str(dl) for dl in definition_levels]))
 
     # repetition levels are skipped if data is at the first level.
     if len(column_metadata.path_in_schema) > 1:
@@ -294,7 +293,7 @@ def read_data_page(fo, schema_helper, page_header, column_metadata,
         for i in range(daph.num_values):
             vals.append(
                 encoding.read_plain(io_obj, column_metadata.type, None))
-        logger.debug("  Values: %s", len(vals)); #",".join([str(x) for x in vals]))
+        logger.debug("  Values: %s", len(vals))
     elif daph.encoding == Encoding.PLAIN_DICTIONARY:
         # bit_width is stored as single byte.
         bit_width = struct.unpack("<B", io_obj.read(1))[0]

--- a/parquet/encoding.py
+++ b/parquet/encoding.py
@@ -130,7 +130,7 @@ def _mask_for_bits(i):
 def read_bitpacked(fo, header, width):
     """Reads a bitpacked run of the rle/bitpack hybrid.
 
-    Currently only supports width <=8 (doesn't support crossing bytes).
+    Supports width >8 (crossing bytes).
     """
     num_groups = header >> 1
     count = num_groups * 8


### PR DESCRIPTION
use a dynamic bytes window to hold current bitpack run.
fix bitpack-run size calculation (per parquet-format/Encoding.md, 8 members will be packed all together).

The script could now correctly process parquet-compatibility/parquet-testdata/impala/1.1.1-NONE/customer.impala.parquet
