### PR TITLE
Add closing paren to tuple expression

### DIFF
--- a/parquet/bitstring.py
+++ b/parquet/bitstring.py
@@ -16,5 +16,5 @@ class BitString(object):
 		except AttributeError:
 			if key < 0 or key >= length:
 				raise IndexError()
-			byte_index, bit_offset = divmod(self.offset + key), 8)
+			byte_index, bit_offset = (divmod(self.offset + key), 8)
 			return self.bytes[byte_index] & SINGLE_BIT_MASK[bit_offset]


### PR DESCRIPTION
Under Python 2.7.6, this file didn't compile for me as-is.  I still need to clone and rerun the test suite, but I thought I'd try Github's nifty "fork and edit online" feature.  Will comment again when the tests pass.