### PR TITLE
implements bulk reads for plain encoding.

### DIFF
--- a/parquet/__init__.py
+++ b/parquet/__init__.py
@@ -316,9 +316,8 @@ def read_data_page(fo, schema_helper, page_header, column_metadata,
     # TODO Actually use the definition and repetition levels.
 
     if daph.encoding == parquet_thrift.Encoding.PLAIN:
-        for i in range(daph.num_values):
-            vals.append(
-                encoding.read_plain(io_obj, column_metadata.type, None))
+        vals.extend(
+            encoding.read_plain(io_obj, column_metadata.type, daph.num_values))
         if debug_logging:
             logger.debug("  Values: %s", len(vals))
     elif daph.encoding == parquet_thrift.Encoding.PLAIN_DICTIONARY:
@@ -346,12 +345,8 @@ def read_data_page(fo, schema_helper, page_header, column_metadata,
 def read_dictionary_page(fo, page_header, column_metadata):
     raw_bytes = _read_page(fo, page_header, column_metadata)
     io_obj = io.BytesIO(raw_bytes)
-    dict_items = []
-    while io_obj.tell() < len(raw_bytes):
-        # TODO - length for fixed byte array
-        dict_items.append(
-            encoding.read_plain(io_obj, column_metadata.type, None))
-    return dict_items
+    return encoding.read_plain(io_obj, column_metadata.type,
+        page_header.dictionary_page_header.num_values)
 
 
 def DictReader(fo, columns=None):

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -14,32 +14,32 @@ class TestPlain(unittest.TestCase):
         self.assertEquals(
             999,
             parquet.encoding.read_plain_int32(
-                io.BytesIO(struct.pack("<i", 999))))
+                io.BytesIO(struct.pack("<i", 999)), 1)[0])
 
     def test_int64(self):
         self.assertEquals(
             999,
             parquet.encoding.read_plain_int64(
-                io.BytesIO(struct.pack("<q", 999))))
+                io.BytesIO(struct.pack("<q", 999)), 1)[0])
 
     def test_int96(self):
         self.assertEquals(
             999,
             parquet.encoding.read_plain_int96(
-                io.BytesIO(struct.pack("<qi", 0, 999))))
+                io.BytesIO(struct.pack("<qi", 0, 999)), 1)[0])
 
     def test_float(self):
         self.assertAlmostEquals(
             9.99,
             parquet.encoding.read_plain_float(
-                io.BytesIO(struct.pack("<f", 9.99))),
+                io.BytesIO(struct.pack("<f", 9.99)), 1)[0],
             2)
 
     def test_double(self):
         self.assertEquals(
             9.99,
             parquet.encoding.read_plain_double(
-                io.BytesIO(struct.pack("<d", 9.99))))
+                io.BytesIO(struct.pack("<d", 9.99)), 1)[0])
 
     def test_fixed(self):
         data = b"foobar"
@@ -60,6 +60,14 @@ class TestPlain(unittest.TestCase):
             data[:3],
             parquet.encoding.read_plain(
                 fo, parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY, 3))
+
+    def test_boolean(self):
+        data = 0b1101
+        fo = io.BytesIO(struct.pack("<i", data))
+        self.assertEquals(
+            [True, False, True, True],
+            parquet.encoding.read_plain_boolean(fo, 1)[:4]
+        )
 
 
 class TestRle(unittest.TestCase):


### PR DESCRIPTION
By using bulk operations in struct.unpack, improve performance.
Also add implementation for previously unsupported boolean type.