### PR TITLE
Fix issues invoking struct methods.

### DIFF
--- a/parquet/__init__.py
+++ b/parquet/__init__.py
@@ -64,7 +64,7 @@ def _check_footer_magic_bytes(file_obj):
 def _get_footer_size(file_obj):
     """Read the footer size in bytes, which is serialized as little endian."""
     file_obj.seek(-8, 2)
-    tup = struct.unpack("<i", file_obj.read(4))
+    tup = struct.unpack(b"<i", file_obj.read(4))
     return tup[0]
 
 
@@ -348,7 +348,7 @@ def read_data_page(file_obj, schema_helper, page_header, column_metadata,
 
     elif daph.encoding == parquet_thrift.Encoding.PLAIN_DICTIONARY:
         # bit_width is stored as single byte.
-        bit_width = struct.unpack("<B", io_obj.read(1))[0]
+        bit_width = struct.unpack(b"<B", io_obj.read(1))[0]
         if debug_logging:
             logger.debug("bit_width: %d", bit_width)
 

--- a/parquet/converted_types.py
+++ b/parquet/converted_types.py
@@ -53,8 +53,8 @@ def _convert_unsigned(data, fmt):
     """Convert data from signed to unsigned in bulk."""
     num = len(data)
     return struct.unpack(
-        "{}{}".format(num, fmt.upper()),
-        struct.pack("{}{}".format(num, fmt), *data)
+        "{}{}".format(num, fmt.upper()).encode("utf-8"),
+        struct.pack("{}{}".format(num, fmt).encode("utf-8"), *data)
     )
 
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -16,28 +16,28 @@ class TestPlain(unittest.TestCase):
         self.assertEqual(
             999,
             parquet.encoding.read_plain_int32(
-                io.BytesIO(struct.pack("<i", 999)), 1)[0])
+                io.BytesIO(struct.pack(b"<i", 999)), 1)[0])
 
     def test_int64(self):
         """Test reading bytes containing int64 data."""
         self.assertEqual(
             999,
             parquet.encoding.read_plain_int64(
-                io.BytesIO(struct.pack("<q", 999)), 1)[0])
+                io.BytesIO(struct.pack(b"<q", 999)), 1)[0])
 
     def test_int96(self):
         """Test reading bytes containing int96 data."""
         self.assertEqual(
             999,
             parquet.encoding.read_plain_int96(
-                io.BytesIO(struct.pack("<qi", 0, 999)), 1)[0])
+                io.BytesIO(struct.pack(b"<qi", 0, 999)), 1)[0])
 
     def test_float(self):
         """Test reading bytes containing float data."""
         self.assertAlmostEquals(
             9.99,
             parquet.encoding.read_plain_float(
-                io.BytesIO(struct.pack("<f", 9.99)), 1)[0],
+                io.BytesIO(struct.pack(b"<f", 9.99)), 1)[0],
             2)
 
     def test_double(self):
@@ -45,7 +45,7 @@ class TestPlain(unittest.TestCase):
         self.assertEqual(
             9.99,
             parquet.encoding.read_plain_double(
-                io.BytesIO(struct.pack("<d", 9.99)), 1)[0])
+                io.BytesIO(struct.pack(b"<d", 9.99)), 1)[0])
 
     def test_fixed(self):
         """Test reading bytes containing fixed bytes data."""
@@ -72,7 +72,7 @@ class TestPlain(unittest.TestCase):
     def test_boolean(self):
         """Test reading bytes containing boolean data."""
         data = 0b1101
-        fo = io.BytesIO(struct.pack("<i", data))
+        fo = io.BytesIO(struct.pack(b"<i", data))
         self.assertEqual(
             [True, False, True, True],
             parquet.encoding.read_plain_boolean(fo, 1)[:4]
@@ -84,7 +84,7 @@ class TestRle(unittest.TestCase):
 
     def testFourByteValue(self):
         """Test reading a run with a single four-byte value."""
-        fo = io.BytesIO(struct.pack("<i", 1 << 30))
+        fo = io.BytesIO(struct.pack(b"<i", 1 << 30))
         out = parquet.encoding.read_rle(fo, 2 << 1, 30, True)
         self.assertEqual([1 << 30] * 2, list(out))
 
@@ -94,13 +94,13 @@ class TestVarInt(unittest.TestCase):
 
     def testSingleByte(self):
         """Test reading a single byte value."""
-        fo = io.BytesIO(struct.pack("<B", 0x7F))
+        fo = io.BytesIO(struct.pack(b"<B", 0x7F))
         out = parquet.encoding.read_unsigned_var_int(fo)
         self.assertEqual(0x7F, out)
 
     def testFourByte(self):
         """Test reading a four byte value."""
-        fo = io.BytesIO(struct.pack("<BBBB", 0xFF, 0xFF, 0xFF, 0x7F))
+        fo = io.BytesIO(struct.pack(b"<BBBB", 0xFF, 0xFF, 0xFF, 0x7F))
         out = parquet.encoding.read_unsigned_var_int(fo)
         self.assertEqual(0x0FFFFFFF, out)
 


### PR DESCRIPTION
struct pack/unpack expect a bytestring, but unicode encoding is
being used in some cases.

Refs: https://github.com/jcrobak/parquet-python/issues/40