### PR TITLE
Fixes parsing of int96

### DIFF
--- a/parquet/__main__.py
+++ b/parquet/__main__.py
@@ -60,5 +60,6 @@ def main(argv=None):
     if not args.no_data:
         parquet.dump(args.file, args)
 
+
 if __name__ == '__main__':
     main()

--- a/parquet/encoding.py
+++ b/parquet/encoding.py
@@ -50,9 +50,8 @@ def read_plain_int64(file_obj, count):
 
 def read_plain_int96(file_obj, count):
     """Read `count` 96-bit ints using the plain encoding."""
-    items = struct.unpack(b"<qi" * count, file_obj.read(12) * count)
-    args = [iter(items)] * 2
-    return [q << 32 | i for (q, i) in zip(*args)]
+    items = struct.unpack(b"<" + b"qi" * count, file_obj.read(12 * count))
+    return [q << 32 | i for (q, i) in zip(items[0::2], items[1::2])]
 
 
 def read_plain_float(file_obj, count):

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -28,9 +28,9 @@ class TestPlain(unittest.TestCase):
     def test_int96(self):
         """Test reading bytes containing int96 data."""
         self.assertEqual(
-            999,
+            [999, 1 << 32 | 1000],
             parquet.encoding.read_plain_int96(
-                io.BytesIO(struct.pack(b"<qi", 0, 999)), 1)[0])
+                io.BytesIO(struct.pack(b"<qiqi", 0, 999, 1, 1000)), 2))
 
     def test_float(self):
         """Test reading bytes containing float data."""


### PR DESCRIPTION
Previously, an incorrect format string was used and only the first
12 bytes were read from the stream.

Refs #49.