### PR TITLE
Fix IndexError when width is zero

### DIFF
--- a/parquet/encoding.py
+++ b/parquet/encoding.py
@@ -147,6 +147,9 @@ def read_bitpacked(file_obj, header, width, debug_logging):
     if debug_logging:
         logger.debug("Reading a bit-packed run with: %s groups, count %s, bytes %s",
                      num_groups, count, byte_count)
+    if width == 0:
+        res =  [0 for _ in range(count)]
+        return  res
     raw_bytes = array.array(ARRAY_BYTE_STR, file_obj.read(byte_count)).tolist()
     current_byte = 0
     data = raw_bytes[current_byte]


### PR DESCRIPTION
In func `read_bitpacked`, when width == 0, byte_count is zero, and raw_bytes == []. 

Then IndexError when access the raw_bytes