### PR TITLE
Avoid using codecs.iterdecode() when reading the dictionary page since it swallows empty strings

### DIFF
--- a/parquet/converted_types.py
+++ b/parquet/converted_types.py
@@ -73,7 +73,7 @@ def convert_column(data, schemae):
     elif ctype == parquet_thrift.ConvertedType.TIMESTAMP_MILLIS:
         return [datetime.datetime.utcfromtimestamp(d / 1000.0) for d in data]
     elif ctype == parquet_thrift.ConvertedType.UTF8:
-        return list(codecs.iterdecode(data, "utf-8"))
+        return [codecs.decode(item, "utf-8") for item in data]
     elif ctype == parquet_thrift.ConvertedType.UINT_8:
         return _convert_unsigned(data, 'b')
     elif ctype == parquet_thrift.ConvertedType.UINT_16:


### PR DESCRIPTION
For dictionary pages containing empty strings, `codecs.iterdecode()` silently swallows them and returns an incorrect dictionary.

This issue affects all Parquet files with string column chunks containing empty strings and encoded using dictionary encoding.

Please refer to [this StackOverflow link][1] for more details.

[1]: http://stackoverflow.com/questions/43904440/why-codecs-iterdecode-eats-empty-strings/